### PR TITLE
Update Productboard work experience and Prisma role

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@ pre-commit:
   commands:
     format:
       glob: '*.{js,ts,mts,astro,md,mdx,json,yml,yaml,css}'
-      run: bunx oxfmt -c .oxlintrc.json {staged_files}
+      run: bunx oxfmt -c .oxlintrc.json --no-error-on-unmatched-pattern {staged_files}
     lint:
       glob: '*.{js,ts,mts,astro}'
       run: bunx oxlint -c .oxlintrc.json {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,8 +2,8 @@ pre-commit:
   parallel: true
   commands:
     format:
-      glob: '*.{js,ts,mts,astro,md,mdx,json,yml,yaml,css}'
+      glob: "*.{js,ts,mts,astro,md,mdx,json,yml,yaml,css}"
       run: bunx oxfmt -c .oxlintrc.json --no-error-on-unmatched-pattern {staged_files}
     lint:
-      glob: '*.{js,ts,mts,astro}'
+      glob: "*.{js,ts,mts,astro}"
       run: bunx oxlint -c .oxlintrc.json {staged_files}

--- a/src/components/work.astro
+++ b/src/components/work.astro
@@ -15,60 +15,55 @@ import WorkExperience from "./work-experience.astro";
             <p class="pb-4">
                 Built gradual deployments for frontend applications on top of
                 Cloudflare Workers and our monitoring tools. The system
-                automatically detects faulty deployments and rolls back
-                changes, keeping production stable as shipping velocity
-                increased.
+                automatically detects faulty deployments and rolls back changes,
+                keeping production stable as shipping velocity increased.
             </p>
             <p class="pb-4">
-                Led the migration away from slow tooling like <b>ESLint</b> to
-                a modern stack built on <b>oxlint</b>, <b>oxfmt</b>, and <b
-                    >tsgo</b
-                >. This provided faster feedback loops for both engineers and
-                AI agents working in the monorepo. Adjusted the monorepo
-                structure and conventions to work well with agents, and
-                authored a set of <b>skills</b> that codified our workflows so
-                agents could ship reliably across the codebase.
+                Led the migration away from slow tooling like <b>ESLint</b> to a modern
+                stack built on <b>oxlint</b>, <b>oxfmt</b>, and <b>tsgo</b>.
+                This provided faster feedback loops for both engineers and AI
+                agents working in the monorepo. Adjusted the monorepo structure
+                and conventions to work well with agents, and authored a set of <b
+                    >skills</b
+                > that codified our workflows so agents could ship reliably across
+                the codebase.
             </p>
             <p class="pb-4">
-                Worked on multiple legacy code cleanups, removing more than <b
-                    >250+</b
-                >
-                cyclic dependencies and improving code quality. Implemented best practices
-                for modular design and code organization. This led to improved CI/CD
-                times and reduced the number of projects that need to be checked.
+                Led multiple legacy code cleanups, removing more than <b>250</b>
+                cyclic dependencies and improving overall code quality. Established
+                best practices for modular design and code organization, which improved
+                CI/CD times and reduced the number of projects that needed to be rechecked
+                on every change.
             </p>
             <p class="pb-4">
                 Migrated multiple applications from <b>Webpack 3</b> to <b
                     >Webpack 5</b
-                >
-                and later to <b>Vite + Rolldown</b> setup. Created multiple plugins
-                and tools to optimize bundle size and prevent accidental increases
-                or introduction of dev packages into production code.
+                >, and later to a <b>Vite + Rolldown</b> setup. Built plugins and
+                tooling to optimize bundle size and prevent accidental regressions
+                or dev-only packages slipping into production.
             </p>
             <p class="pb-4">
-                Pushed the introduction of <b>federated GraphQL</b> into the stack.
-                This allowed us to split our monolithic application into multiple
-                services. This created a unified way to fetch data for 90% of use
-                cases. Created tooling for GraphQL schema unification and promoted
-                best <b>Relay</b>
-                patterns.
+                Drove the introduction of <b>federated GraphQL</b> into the stack,
+                splitting our monolithic application into multiple services and unifying
+                data fetching for around 90% of our use cases. Built tooling for GraphQL
+                schema unification and promoted <b>Relay</b> best practices.
             </p>
             <p class="pb-4">
-                Maintained frontend monorepo with more than <b>750</b> packages and
-                <b>1.6 million</b>
-                lines of TypeScript code. I worked on several improvements to enhance
-                CI/CD and overall developer experience in this large codebase.
+                Maintained a frontend monorepo with more than <b>750</b>
+                packages and <b>1.6 million</b> lines of TypeScript code, shipping
+                a number of improvements to CI/CD and the overall developer experience
+                at that scale.
             </p>
             <p class="pb-4">
                 Introduced Cloudflare Workers into the stack and changed how
-                frontend applications are served. This reduced initial load time
-                and decreased <b>TTFB</b> by <b>600ms</b>.
+                frontend applications are served, reducing initial load time and
+                cutting <b>TTFB</b> by <b>600ms</b>.
             </p>
             <p>
-                Resurrected the design system and created the initial version of
-                our new design system, Nucleus. The main goal was unification
-                and introducing new patterns and tools for parity between React
-                components and Figma.
+                Resurrected the design system and built the initial version of
+                our new one, Nucleus. The goal was to unify components and
+                introduce patterns and tools that kept React and Figma in
+                parity.
             </p>
         </WorkExperience>
 
@@ -80,7 +75,8 @@ import WorkExperience from "./work-experience.astro";
             role="Software Engineer"
         >
             <p>
-                Worked on <b>Next.js</b> framework
+                Helped maintain the <b>Next.js</b> framework repository, triaging
+                issues and reviewing community contributions, and shipped
                 <a
                     href="https://github.com/vercel/next.js/pull/7296"
                     target="_blank"
@@ -88,7 +84,8 @@ import WorkExperience from "./work-experience.astro";
                     class="underline hover:text-stone-800"
                 >
                     API routes support</a
-                >, Internal Dashboard, (DNS records, preview deployments).
+                > and other improvements. Also worked on the internal dashboard (DNS
+                records, preview deployments).
             </p>
         </WorkExperience>
 
@@ -99,13 +96,20 @@ import WorkExperience from "./work-experience.astro";
             to="2018-03"
             role="Product Engineer"
         >
-            Built an Electron application <a
+            Built an Electron application, <a
                 href="https://v1.prisma.io/docs/1.34/prisma-admin/overview-el3e/"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="underline hover:text-stone-800">Prisma Admin</a
-            > (predecessor of Prisma Studio). Created a virtual data layer on top
-            of the actual data to display pending changes that have not yet been committed.
+            >, the predecessor of Prisma Studio. Created a virtual data layer on
+            top of the actual data to display pending changes that had not yet
+            been committed. Also maintained
+            <a
+                href="https://github.com/graphql/graphql-playground"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="underline hover:text-stone-800">GraphQL Playground</a
+            >, IDE for exploring GraphQL APIs.
         </WorkExperience>
     </div>
 </section>

--- a/src/components/work.astro
+++ b/src/components/work.astro
@@ -13,6 +13,23 @@ import WorkExperience from "./work-experience.astro";
             role="Frontend Platform Engineer"
         >
             <p class="pb-4">
+                Built gradual deployments for frontend applications on top of
+                Cloudflare Workers and our monitoring tools. The system
+                automatically detects faulty deployments and rolls back
+                changes, keeping production stable as shipping velocity
+                increased.
+            </p>
+            <p class="pb-4">
+                Led the migration away from slow tooling like <b>ESLint</b> to
+                a modern stack built on <b>oxlint</b>, <b>oxfmt</b>, and <b
+                    >tsgo</b
+                >. This provided faster feedback loops for both engineers and
+                AI agents working in the monorepo. Adjusted the monorepo
+                structure and conventions to work well with agents, and
+                authored a set of <b>skills</b> that codified our workflows so
+                agents could ship reliably across the codebase.
+            </p>
+            <p class="pb-4">
                 Worked on multiple legacy code cleanups, removing more than <b
                     >250+</b
                 >
@@ -38,14 +55,14 @@ import WorkExperience from "./work-experience.astro";
             </p>
             <p class="pb-4">
                 Maintained frontend monorepo with more than <b>750</b> packages and
-                <b>1.4 million</b>
+                <b>1.6 million</b>
                 lines of TypeScript code. I worked on several improvements to enhance
                 CI/CD and overall developer experience in this large codebase.
             </p>
             <p class="pb-4">
                 Introduced Cloudflare Workers into the stack and changed how
                 frontend applications are served. This reduced initial load time
-                and decreased <b>P90</b> by <b>800ms</b>.
+                and decreased <b>TTFB</b> by <b>600ms</b>.
             </p>
             <p>
                 Resurrected the design system and created the initial version of
@@ -80,7 +97,7 @@ import WorkExperience from "./work-experience.astro";
             logo="https://www.prisma.io/favicon.ico"
             from="2017-09"
             to="2018-03"
-            role="Frontend Engineer"
+            role="Product Engineer"
         >
             Built an Electron application <a
                 href="https://v1.prisma.io/docs/1.34/prisma-admin/overview-el3e/"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,23 +26,31 @@ import { Image } from "astro:assets";
     <p class="mb-4">
       Software developer passionate about <b>React</b>, <b>GraphQL</b>, <b
         >TypeScript</b
-      >
+      >, and <b>AI</b>.
     </p>
     <p class="mb-4">
       I specialize in building high-performance web applications with modern
-      JavaScript technologies. My expertise includes creating scalable frontend
-      architectures, optimizing application performance, and developing
-      type-safe GraphQL APIs.
+      JavaScript technologies. My expertise includes designing scalable
+      frontend architectures, optimizing application performance, developing
+      type-safe GraphQL APIs, and shaping codebases so AI agents can ship in
+      them reliably.
+    </p>
+    <p class="mb-4">
+      I'm comfortable shipping full products end-to-end across the JavaScript
+      ecosystem — from the UI and backend services to databases and
+      deployment. I enjoy owning the whole stack and wiring the pieces
+      together into something users can actually rely on.
     </p>
     <p class="mb-4">
       Based in the Czech Republic, I focus on delivering exceptional user
       experiences through clean code and thoughtful engineering. I'm
-      particularly interested in performance optimization, developer experience,
-      and building tools that make developers' lives easier.
+      particularly interested in performance optimization, developer
+      experience, and building tools and AI agents that make developers' lives
+      easier.
     </p>
     <p class="mb-4">
-      When I'm not coding, I am spending time with my family, exploring new
-      technologies, playing board games, and enjoying the outdoors.
+      When I'm not coding, I spend time with my family, explore new
+      technologies, play board games, and enjoy the outdoors.
     </p>
   </section>
   <Speaking />


### PR DESCRIPTION
## Summary
- Reorder and expand the Productboard bullets: lead with gradual deployments and the migration to oxlint/oxfmt/tsgo (plus monorepo + skills work for AI agents)
- Bump monorepo size from 1.4M to 1.6M lines of TypeScript and replace the P90/800ms metric with TTFB/600ms to match the "Six Years at Productboard" blog post
- Change the Prisma role from "Frontend Engineer" to "Product Engineer"
- Add `--no-error-on-unmatched-pattern` to the oxfmt pre-commit step so commits touching only `.astro` files don't fail under oxfmt 0.45.0

## Test plan
- [ ] `bun dev` and visually verify the Work Experience section renders the new ordering and copy
- [ ] `bun run check` passes
- [ ] Pre-commit hook succeeds when staging only `.astro` files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated work experience descriptions to reflect current technologies, including deployment automation and code quality tooling
  * Enhanced home page introduction to highlight AI-focused expertise and end-to-end ownership across frontend, backend, databases, and deployment

* **Chores**
  * Updated code formatting configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->