### PR TITLE
Fix grammar and typos in blog posts

### DIFF
--- a/src/content/blog/improve-prototyping-speed-of-prisma.mdx
+++ b/src/content/blog/improve-prototyping-speed-of-prisma.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Improve prototyping speed of Prisma'
-description: 'Automate your database updates with one command.'
-date: '2020-11-22T18:00:00Z'
-image: 'improve-prototyping-speed-of-prisma/og-image.png'
+title: "Improve prototyping speed of Prisma"
+description: "Automate your database updates with one command."
+date: "2020-11-22T18:00:00Z"
+image: "improve-prototyping-speed-of-prisma/og-image.png"
 ---
 
 [Prisma](https://www.prisma.io/) is a really great "next-generation" ORM. It enables developers to work with databases effortlessly. It had one downside, and that was an annoying prototyping developer experience.

--- a/src/content/blog/improve-prototyping-speed-of-prisma.mdx
+++ b/src/content/blog/improve-prototyping-speed-of-prisma.mdx
@@ -5,27 +5,27 @@ date: '2020-11-22T18:00:00Z'
 image: 'improve-prototyping-speed-of-prisma/og-image.png'
 ---
 
-[Prisma](https://www.prisma.io/) is really great "next-generation" ORM. It enables developers to work with databases effortlessly. It had one downside and that was prototyping annoying the developer experience.
+[Prisma](https://www.prisma.io/) is a really great "next-generation" ORM. It enables developers to work with databases effortlessly. It had one downside, and that was an annoying prototyping developer experience.
 
 ## Single command for schema changes
 
-From [2.10.0 release](https://github.com/prisma/prisma/releases/tag/2.10.0) release everything improved with possibility run just one single command! Prisma introduced a new `prisma db` namespace for commands that operates directly against the database.
+The [2.10.0 release](https://github.com/prisma/prisma/releases/tag/2.10.0) improved everything with the possibility of running just one single command! Prisma introduced a new `prisma db` namespace for commands that operate directly against the database.
 
 ```bash
 prisma db push --preview-feature
 ```
 
-It greatly improves prototyping speed, because the developer is no longer required to write migrations. The command's usage is mainly for prototyping and local environments. For production environments, you should use `prisma migrate` commands to run propper database migrations.
+It greatly improves prototyping speed, because the developer is no longer required to write migrations. The command's usage is mainly for prototyping and local environments. For production environments, you should use `prisma migrate` commands to run proper database migrations.
 
 ## Save and run
 
-If you are using [VSCode](https://code.visualstudio.com/) we can improve prototyping even more. There is [Save and Run](https://marketplace.visualstudio.com/items?itemName=wk-j.save-and-run) extension, which enables us to run a command on save. You can install this extension trough `Extensions` in VScode or run this command:
+If you are using [VSCode](https://code.visualstudio.com/), we can improve prototyping even more. There is the [Save and Run](https://marketplace.visualstudio.com/items?itemName=wk-j.save-and-run) extension, which enables us to run a command on save. You can install this extension through `Extensions` in VSCode or run this command:
 
 ```bash
 code --install-extension wk-j.save-and-run
 ```
 
-Next, you need to add settings file to your `Prisma` project to enable `Save and Run` to work on `schema.prisma` file.
+Next, you need to add a settings file to your `Prisma` project to enable `Save and Run` to work on the `schema.prisma` file.
 
 ```json showLineNumbers title=.vscode/settings.json
 {
@@ -41,13 +41,13 @@ Next, you need to add settings file to your `Prisma` project to enable `Save and
 }
 ```
 
-Here you can see whole flow in action. It deploys a new schema to database and generates types for `PrismaClient`.
+Here you can see the whole flow in action. It deploys a new schema to the database and generates types for `PrismaClient`.
 
 ![Run Prisma db push command on save](/improve-prototyping-speed-of-prisma/run-on-save-prisma.gif)
 
-You can use `Save and run` with oter tools, such as:
+You can use `Save and run` with other tools, such as:
 
 - [GraphQL code generator](https://graphql-code-generator.com/) - generating code from your `GraphQL` schema
 - [Nexus.js](https://nexusjs.org/) - generating code-first `GraphQL` schema
 
-If you are not using `VSCode` you can use [Watchman](https://facebook.github.io/watchman/), [entr](https://github.com/eradman/entr) or any other tools for watching file change.
+If you are not using `VSCode`, you can use [Watchman](https://facebook.github.io/watchman/), [entr](https://github.com/eradman/entr), or any other tool for watching file changes.

--- a/src/content/blog/my-first-post.mdx
+++ b/src/content/blog/my-first-post.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'My First Post!'
-description: 'Starting to write my blog finally!'
-date: '2020-10-26T08:41:03Z'
+title: "My First Post!"
+description: "Starting to write my blog finally!"
+date: "2020-10-26T08:41:03Z"
 ---
 
 👋 I am Lukáš, most of you know me as **Huvik**, a software developer from the **Czech&nbsp;Republic** passionate about **React**, **TypeScript**, and **GraphQL**.

--- a/src/content/blog/my-first-post.mdx
+++ b/src/content/blog/my-first-post.mdx
@@ -4,8 +4,8 @@ description: 'Starting to write my blog finally!'
 date: '2020-10-26T08:41:03Z'
 ---
 
-👋 I am Lukáš most of you know me as **Huvik**, software developer from **Czech&nbsp;Republic** passionate about **React**, **TypeScript** and **GraphQL**.
+👋 I am Lukáš, most of you know me as **Huvik**, a software developer from the **Czech&nbsp;Republic** passionate about **React**, **TypeScript**, and **GraphQL**.
 
-This idea about writing was in my head for a few years already. The main reason was to share my experience and knowledge with what I gathered trough my life as a developer. The second one was to improve my writing skills which were lacking last few years.
+This idea about writing has been in my head for a few years already. The main reason was to share the experience and knowledge I gathered through my life as a developer. The second was to improve my writing skills, which have been lacking the last few years.
 
 I am going to write about useful tricks and tips regarding **Next.js**, **GraphQL**, and **TypeScript**. You can expect a lot of code examples and maybe some life stories. I hope you are going to like it!

--- a/src/content/blog/six-years-at-productboard.mdx
+++ b/src/content/blog/six-years-at-productboard.mdx
@@ -62,13 +62,13 @@ Then Ondrej joined, and we completed many different migrations. To name a few: Y
 
 ## CI/CD and Modern Tooling
 
-Our CI/CD was getting slower with increase of size of our monorepo. [Jirka](https://x.com/synaptiko_o) joined team and helped us to create a lot of improvements and making Nx faster. We tried Nx Cloud and task distribution. It was working, but never achieved the end goal, because of various issues.
+Our CI/CD was getting slower with the increase in the size of our monorepo. [Jirka](https://x.com/synaptiko_o) joined the team and helped us create a lot of improvements and make Nx faster. We tried Nx Cloud and task distribution. It was working, but never achieved the end goal because of various issues.
 
-Then age of "new" modern tools began. We tried to enable TypeScript project references, it was slow. We decided to try out **tsgo** and everything was faster and better and simpler.
+Then the age of "new" modern tools began. We tried to enable TypeScript project references, but it was slow. We decided to try out **tsgo**, and everything was faster, better, and simpler.
 
 ## AI
 
-Then AI made a significant impact, changing everything. Code is now inexpensive, enabling the production of anything, but maintaining quality and stability is crucial. We adjusted our monorepo to work more effectively with AI agents and migrated away from slow tools like ESLint to provide our agents and team with faster feedback loops. We had full setup with **oxlint**, **oxfmt** and **tsgo**.
+Then AI made a significant impact, changing everything. Code is now inexpensive, enabling the production of anything, but maintaining quality and stability is crucial. We adjusted our monorepo to work more effectively with AI agents and migrated away from slow tools like ESLint to provide our agents and team with faster feedback loops. We had a full setup with **oxlint**, **oxfmt**, and **tsgo**.
 
 We drastically transformed our CI/CD process. Jirka created a simplified version of task distribution to better suit our needs. We iterated on multiple tools and models and ultimately decided it is best to focus on one, as things are changing rapidly and models are improving every day. If you want to **ship value, you should focus on shipping** and not trying models all the time.
 
@@ -78,4 +78,4 @@ One of the last projects I worked on involved gradual deployments of frontend ap
 
 ## Thank You
 
-This summarizes my journey at Productboard. It was a wild ride, and I made many friends while shipping numerous improvements and features. When I left the frontend codebase had more then **1.6 milion lines of codes** and more then **750+** libraries. I significantly enhanced our developers' day-to-day experience. We If something sounds interesting or you want to discuss it, let me know. I am eager to talk about these topics. Thank you for your attention, and yes, I am open to new opportunities.
+This summarizes my journey at Productboard. It was a wild ride, and I made many friends while shipping numerous improvements and features. When I left, the frontend codebase had more than **1.6 million lines of code** and more than **750+** libraries. I significantly enhanced our developers' day-to-day experience. If something sounds interesting or you want to discuss it, let me know. I am eager to talk about these topics. Thank you for your attention, and yes, I am open to new opportunities.


### PR DESCRIPTION
## Summary

Cleans up grammar, typos, and awkward phrasing across three blog posts: `improve-prototyping-speed-of-prisma.mdx`, `my-first-post.mdx`, and `six-years-at-productboard.mdx`. Fixes include missing articles, comma splices, duplicated words (`release release`), misspellings (`trough`, `propper`, `oter`, `milion`, `more then`), and a stray `We` in the Productboard closing paragraph.

No content or meaning was changed — only readability.