### PR TITLE
fix(og): switch OG image endpoint to cf-workers-og

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,10 +12,8 @@
         "@fontsource/space-mono": "5.2.9",
         "@lucide/astro": "1.8.0",
         "astro": "6.1.8",
-        "satori": "0.26.0",
-        "satori-astro": "0.4.0",
-        "satori-html": "0.3.2",
-        "sharp": "0.34.5",
+        "cf-workers-og": "3.0.1",
+        "react": "19.2.5",
         "tailwindcss": "4.2.2",
         "typescript": "6.0.3",
       },
@@ -287,6 +285,8 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
+    "@resvg/resvg-wasm": ["@resvg/resvg-wasm@2.6.2", "", {}, "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw=="],
+
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.0", "", { "os": "android", "cpu": "arm" }, "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A=="],
@@ -447,6 +447,8 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
+    "cf-workers-og": ["cf-workers-og@3.0.1", "", { "dependencies": { "@resvg/resvg-wasm": "^2.6.2", "htmlparser2": "^10.0.0", "satori": "0.18.3", "style-to-js": "^1.1.21" }, "peerDependencies": { "react": ">=18.0.0" }, "optionalPeers": ["react"] }, "sha512-oIuLE1eIWMl8m6RBZdNHKrnJlcGU0qvkp0U8hOLth4r1YV5f922vuqereY3iOYqmtdeiISPh+sHFci3HKqOvaw=="],
+
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -529,7 +531,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
@@ -614,6 +616,8 @@
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
@@ -883,6 +887,8 @@
 
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
@@ -931,11 +937,7 @@
 
     "rollup": ["rollup@4.60.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.0", "@rollup/rollup-android-arm64": "4.60.0", "@rollup/rollup-darwin-arm64": "4.60.0", "@rollup/rollup-darwin-x64": "4.60.0", "@rollup/rollup-freebsd-arm64": "4.60.0", "@rollup/rollup-freebsd-x64": "4.60.0", "@rollup/rollup-linux-arm-gnueabihf": "4.60.0", "@rollup/rollup-linux-arm-musleabihf": "4.60.0", "@rollup/rollup-linux-arm64-gnu": "4.60.0", "@rollup/rollup-linux-arm64-musl": "4.60.0", "@rollup/rollup-linux-loong64-gnu": "4.60.0", "@rollup/rollup-linux-loong64-musl": "4.60.0", "@rollup/rollup-linux-ppc64-gnu": "4.60.0", "@rollup/rollup-linux-ppc64-musl": "4.60.0", "@rollup/rollup-linux-riscv64-gnu": "4.60.0", "@rollup/rollup-linux-riscv64-musl": "4.60.0", "@rollup/rollup-linux-s390x-gnu": "4.60.0", "@rollup/rollup-linux-x64-gnu": "4.60.0", "@rollup/rollup-linux-x64-musl": "4.60.0", "@rollup/rollup-openbsd-x64": "4.60.0", "@rollup/rollup-openharmony-arm64": "4.60.0", "@rollup/rollup-win32-arm64-msvc": "4.60.0", "@rollup/rollup-win32-ia32-msvc": "4.60.0", "@rollup/rollup-win32-x64-gnu": "4.60.0", "@rollup/rollup-win32-x64-msvc": "4.60.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ=="],
 
-    "satori": ["satori@0.26.0", "", { "dependencies": { "@shuding/opentype.js": "1.4.0-beta.0", "css-background-parser": "^0.1.0", "css-box-shadow": "1.0.0-3", "css-gradient-parser": "^0.0.17", "css-to-react-native": "^3.0.0", "emoji-regex-xs": "^2.0.1", "escape-html": "^1.0.3", "linebreak": "^1.1.0", "parse-css-color": "^0.2.1", "postcss-value-parser": "^4.2.0", "yoga-layout": "^3.2.1" } }, "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA=="],
-
-    "satori-astro": ["satori-astro@0.4.0", "", { "dependencies": { "satori": "^0.26.0" }, "peerDependencies": { "astro": "^4.12.0 || ^5.0.0 || ^6.0.0", "sharp": ">=0.33.3 <1.0.0" } }, "sha512-mxywTqpPnmAz256UhiwnmybMooDyNTFWm4Z0O4d+v83Ejhsr5h1vOs4+DSf90WYBJCidJqNHKmZFekCFuDurcQ=="],
-
-    "satori-html": ["satori-html@0.3.2", "", { "dependencies": { "ultrahtml": "^1.2.0" } }, "sha512-wjTh14iqADFKDK80e51/98MplTGfxz2RmIzh0GqShlf4a67+BooLywF17TvJPD6phO0Hxm7Mf1N5LtRYvdkYRA=="],
+    "satori": ["satori@0.18.3", "", { "dependencies": { "@shuding/opentype.js": "1.4.0-beta.0", "css-background-parser": "^0.1.0", "css-box-shadow": "1.0.0-3", "css-gradient-parser": "^0.0.17", "css-to-react-native": "^3.0.0", "emoji-regex-xs": "^2.0.1", "escape-html": "^1.0.3", "linebreak": "^1.1.0", "parse-css-color": "^0.2.1", "postcss-value-parser": "^4.2.0", "yoga-layout": "^3.2.1" } }, "sha512-T3DzWNmnrfVmk2gCIlAxLRLbGkfp3K7TyRva+Byyojqu83BNvnMeqVeYRdmUw4TKCsyH4RiQ/KuF/I4yEzgR5A=="],
 
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
@@ -1106,6 +1108,8 @@
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "sitemap/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 

--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
     "@fontsource/space-mono": "5.2.9",
     "@lucide/astro": "1.8.0",
     "astro": "6.1.8",
-    "satori": "0.26.0",
-    "satori-astro": "0.4.0",
-    "satori-html": "0.3.2",
-    "sharp": "0.34.5",
+    "cf-workers-og": "3.0.1",
+    "react": "19.2.5",
     "tailwindcss": "4.2.2",
     "typescript": "6.0.3"
   },

--- a/src/lib/og-template.tsx
+++ b/src/lib/og-template.tsx
@@ -1,0 +1,73 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource react */
+/**
+ * JSX template for the runtime OG image.
+ *
+ * Lives outside `src/pages/` because Astro only accepts `.astro`, `.md`,
+ * `.mdx`, `.html`, `.js`, and `.ts` as page entries — `.tsx` is rejected
+ * there. The endpoint at `src/pages/og-image.png.ts` imports this helper
+ * and hands the element to `cf-workers-og`'s `ImageResponse.create`.
+ */
+import type { ReactElement } from 'react';
+
+export type OGTemplateProps = {
+  title: string;
+  description: string;
+  avatarUrl: string;
+};
+
+export function OGTemplate({ title, description, avatarUrl }: OGTemplateProps): ReactElement {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        height: '100%',
+        backgroundColor: '#ffffff',
+        padding: '80px',
+        fontFamily: "'Space Mono', monospace",
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 64,
+          fontWeight: 700,
+          color: '#0a0a0a',
+          marginBottom: 24,
+          lineHeight: 1.2,
+        }}
+      >
+        {title}
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 32,
+          color: '#525252',
+          flex: 1,
+          lineHeight: 1.4,
+        }}
+      >
+        {description}
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          marginTop: 40,
+        }}
+      >
+        <img
+          src={avatarUrl}
+          style={{ width: 80, height: 80, borderRadius: '50%', marginRight: 16 }}
+        />
+        <div style={{ display: 'flex', fontSize: 20, fontWeight: 700, color: '#0a0a0a' }}>
+          Lukáš Huvar
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/og-image.png.ts
+++ b/src/pages/og-image.png.ts
@@ -1,154 +1,48 @@
 /**
- * Dynamic OG image generation endpoint.
+ * Runtime OG image generation on Cloudflare Workers.
  *
- * Renders a 1200x630 PNG via satori using Space Mono fonts and the author's
- * avatar. Accepts `title` and `description` query parameters to customise
- * the card; falls back to site-wide defaults when omitted.
+ * Uses `cf-workers-og` (satori + resvg-wasm) so the endpoint works on the
+ * Workers runtime — no `fs`, `sharp`, or `process.cwd()` required. Fonts
+ * are fetched from Google Fonts on first request and cached via the
+ * library's `cache` helper (pass the Workers `ctx` so refetches are rare).
  *
- * Font files are read from disk and cached in-memory across requests so
- * subsequent invocations skip filesystem I/O. The author avatar is resized
- * with sharp and base64-inlined into the satori HTML template.
+ * Query parameters:
+ * - `title`       – headline text (default: site title)
+ * - `description` – subtitle text (default: site description)
+ *
+ * The JSX template lives in `src/lib/og-template.tsx` — Astro rejects `.tsx`
+ * inside `src/pages/`, so the element is built there and imported here.
  *
  * @module og-image
  */
 import type { APIRoute } from 'astro';
-import { satoriAstroOG } from 'satori-astro';
-import { html } from 'satori-html';
-import { readFile } from 'fs/promises';
-import { join } from 'path';
+import { ImageResponse, GoogleFont, cache } from 'cf-workers-og';
+import { OGTemplate } from '../lib/og-template';
 
-/** Disable prerendering so query parameters are available at request time. */
+/** Disable prerendering so query params and the Workers runtime are available. */
 export const prerender = false;
 
-/** In-memory cache for loaded font ArrayBuffers, populated on first request. */
-let fontCache: { latin: ArrayBuffer; latinExt: ArrayBuffer } | null = null;
+export const GET: APIRoute = async ({ url, locals }) => {
+  cache.setExecutionContext(locals.cfContext);
 
-/**
- * Load Space Mono Latin and Latin Extended font files from `@fontsource`.
- *
- * Results are cached in {@link fontCache} so the filesystem is only hit once
- * per process lifetime. The returned ArrayBuffers are sliced from the
- * underlying Node Buffer to guarantee correct byte offsets for satori.
- *
- * @returns Cached font data for both character sets.
- */
-async function getFonts() {
-  if (fontCache) {
-    return fontCache;
-  }
+  const title = url.searchParams.get('title') || 'Huvik - software developer';
+  const description =
+    url.searchParams.get('description') || 'A software developer from the Czech Republic.';
 
-  const fontPathLatin = join(
-    process.cwd(),
-    'node_modules/@fontsource/space-mono/files/space-mono-latin-400-normal.woff',
-  );
-  const fontPathLatinExt = join(
-    process.cwd(),
-    'node_modules/@fontsource/space-mono/files/space-mono-latin-ext-400-normal.woff',
-  );
+  const avatarUrl = new URL('/lukas-huvar.jpg', url.origin).toString();
 
-  const latinBuffer = await readFile(fontPathLatin);
-  const latinExtBuffer = await readFile(fontPathLatinExt);
-
-  fontCache = {
-    latin: latinBuffer.buffer.slice(
-      latinBuffer.byteOffset,
-      latinBuffer.byteOffset + latinBuffer.byteLength,
-    ),
-    latinExt: latinExtBuffer.buffer.slice(
-      latinExtBuffer.byteOffset,
-      latinExtBuffer.byteOffset + latinExtBuffer.byteLength,
-    ),
-  };
-  return fontCache;
-}
-
-/**
- * GET handler that generates an OG image as a PNG response.
- *
- * Query parameters:
- * - `title`       – headline text (default: "Huvik - software developer")
- * - `description` – subtitle text (default: "A software developer from the Czech Republic.")
- *
- * The response is served with an immutable `Cache-Control` header (1 year)
- * so CDN edges and browsers can cache the generated image indefinitely.
- */
-export const GET: APIRoute = async ({ url }) => {
-  try {
-    // Get query parameters (only title and description)
-    const title = url.searchParams.get('title') || 'Huvik - software developer';
-    const description =
-      url.searchParams.get('description') || 'A software developer from the Czech Republic.';
-
-    // Author information is fixed
-    const author = 'Lukáš Huvar';
-    const authorImage = '/lukas-huvar.jpg';
-
-    // Load both fonts for full character support
-    const fonts = await getFonts();
-
-    // Load and process the author image
-    let avatarBase64 = '';
-    try {
-      const imagePath = join(process.cwd(), 'public', authorImage.replace(/^\//, ''));
-      const imageBuffer = await readFile(imagePath);
-      const sharp = (await import('sharp')).default;
-      const optimizedImage = await sharp(imageBuffer)
-        .resize(80, 80, { fit: 'cover' })
-        .png()
-        .toBuffer();
-      avatarBase64 = `data:image/png;base64,${optimizedImage.toString('base64')}`;
-    } catch (e) {
-      console.error('Failed to load author image:', e);
-    }
-
-    // Build HTML template as string with image embedded
-    const htmlTemplate = `
-      <div style="display: flex; flex-direction: column; width: 100%; height: 100%; background-color: #ffffff; padding: 80px; font-family: 'Space Mono Latin', 'Space Mono Extended', monospace;">
-        <div style="font-size: 64px; font-weight: bold; color: #0a0a0a; margin-bottom: 24px; line-height: 1.2;">
-          ${title}
-        </div>
-        <div style="font-size: 32px; color: #525252; flex: 1; line-height: 1.4;">
-          ${description}
-        </div>
-        <div style="display: flex; justify-content: flex-end; align-items: center; margin-top: 40px;">
-          ${avatarBase64 ? `<img src="${avatarBase64}" style="width: 80px; height: 80px; border-radius: 50%; margin-right: 16px;" />` : ''}
-          <div style="font-size: 20px; font-weight: bold; color: #0a0a0a;">
-            ${author}
-          </div>
-        </div>
-      </div>
-    `;
-
-    // Generate the OG image
-    return await satoriAstroOG({
-      template: html(htmlTemplate),
+  return ImageResponse.create(
+    OGTemplate({ title, description, avatarUrl }),
+    {
       width: 1200,
       height: 630,
-    }).toResponse({
-      satori: {
-        fonts: [
-          {
-            name: 'Space Mono Latin',
-            data: fonts.latin,
-            weight: 400,
-            style: 'normal',
-          },
-          {
-            name: 'Space Mono Extended',
-            data: fonts.latinExt,
-            weight: 400,
-            style: 'normal',
-          },
-        ],
+      fonts: [
+        new GoogleFont('Space Mono', { weight: 400 }),
+        new GoogleFont('Space Mono', { weight: 700 }),
+      ],
+      headers: {
+        'Cache-Control': 'public, max-age=31536000, immutable',
       },
-      response: {
-        headers: {
-          'Cache-Control': 'public, max-age=31536000, immutable',
-        },
-      },
-    });
-  } catch (error) {
-    console.error('Error generating OG image:', error);
-    return new Response('Error generating image', { status: 500 });
-  }
+    },
+  );
 };

--- a/src/pages/og-image.png.ts
+++ b/src/pages/og-image.png.ts
@@ -15,9 +15,9 @@
  *
  * @module og-image
  */
-import type { APIRoute } from 'astro';
-import { ImageResponse, GoogleFont, cache } from 'cf-workers-og';
-import { OGTemplate } from '../lib/og-template';
+import type { APIRoute } from "astro";
+import { ImageResponse, GoogleFont, cache } from "cf-workers-og";
+import { OGTemplate } from "../lib/og-template";
 
 /** Disable prerendering so query params and the Workers runtime are available. */
 export const prerender = false;
@@ -25,24 +25,21 @@ export const prerender = false;
 export const GET: APIRoute = async ({ url, locals }) => {
   cache.setExecutionContext(locals.cfContext);
 
-  const title = url.searchParams.get('title') || 'Huvik - software developer';
+  const title = url.searchParams.get("title") || "Huvik - software developer";
   const description =
-    url.searchParams.get('description') || 'A software developer from the Czech Republic.';
+    url.searchParams.get("description") || "A software developer from the Czech Republic.";
 
-  const avatarUrl = new URL('/lukas-huvar.jpg', url.origin).toString();
+  const avatarUrl = new URL("/lukas-huvar.jpg", url.origin).toString();
 
-  return ImageResponse.create(
-    OGTemplate({ title, description, avatarUrl }),
-    {
-      width: 1200,
-      height: 630,
-      fonts: [
-        new GoogleFont('Space Mono', { weight: 400 }),
-        new GoogleFont('Space Mono', { weight: 700 }),
-      ],
-      headers: {
-        'Cache-Control': 'public, max-age=31536000, immutable',
-      },
+  return ImageResponse.create(OGTemplate({ title, description, avatarUrl }), {
+    width: 1200,
+    height: 630,
+    fonts: [
+      new GoogleFont("Space Mono", { weight: 400 }),
+      new GoogleFont("Space Mono", { weight: 700 }),
+    ],
+    headers: {
+      "Cache-Control": "public, max-age=31536000, immutable",
     },
-  );
+  });
 };


### PR DESCRIPTION
## Summary

The previous `/og-image.png` endpoint relied on `sharp`, `fs/promises`, and `process.cwd()` — none of which work on the Cloudflare Workers runtime, so every request returned 500.

This rewrites the endpoint on top of [`cf-workers-og`](https://github.com/jillesme/cf-workers-og) (satori + resvg-wasm). Fonts are loaded via `GoogleFont('Space Mono')` and cached across requests with `cache.setExecutionContext(locals.cfContext)`. The author avatar is embedded via an absolute URL and fetched by satori at render time.

The JSX template lives in `src/lib/og-template.tsx` because Astro rejects `.tsx` files inside `src/pages/`; `src/pages/og-image.png.ts` imports it and hands the element to `ImageResponse.create`.

## Test plan
- [x] `bun run build` passes
- [x] `wrangler dev` returns `200 image/png` (1200×630) for `/og-image.png?title=…&description=…`
- [ ] After deploy, verify live URL (e.g. https://huvik.dev/og-image.png?title=Hello&description=World) returns a PNG instead of 500