### PR TITLE
fix(og): provide explicit width/height on avatar img

### DIFF
--- a/src/lib/og-template.tsx
+++ b/src/lib/og-template.tsx
@@ -8,7 +8,7 @@
  * there. The endpoint at `src/pages/og-image.png.ts` imports this helper
  * and hands the element to `cf-workers-og`'s `ImageResponse.create`.
  */
-import type { ReactElement } from 'react';
+import type { ReactElement } from "react";
 
 export type OGTemplateProps = {
   title: string;
@@ -20,21 +20,21 @@ export function OGTemplate({ title, description, avatarUrl }: OGTemplateProps): 
   return (
     <div
       style={{
-        display: 'flex',
-        flexDirection: 'column',
-        width: '100%',
-        height: '100%',
-        backgroundColor: '#ffffff',
-        padding: '80px',
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        backgroundColor: "#ffffff",
+        padding: "80px",
         fontFamily: "'Space Mono', monospace",
       }}
     >
       <div
         style={{
-          display: 'flex',
+          display: "flex",
           fontSize: 64,
           fontWeight: 700,
-          color: '#0a0a0a',
+          color: "#0a0a0a",
           marginBottom: 24,
           lineHeight: 1.2,
         }}
@@ -43,9 +43,9 @@ export function OGTemplate({ title, description, avatarUrl }: OGTemplateProps): 
       </div>
       <div
         style={{
-          display: 'flex',
+          display: "flex",
           fontSize: 32,
-          color: '#525252',
+          color: "#525252",
           flex: 1,
           lineHeight: 1.4,
         }}
@@ -54,17 +54,19 @@ export function OGTemplate({ title, description, avatarUrl }: OGTemplateProps): 
       </div>
       <div
         style={{
-          display: 'flex',
-          justifyContent: 'flex-end',
-          alignItems: 'center',
+          display: "flex",
+          justifyContent: "flex-end",
+          alignItems: "center",
           marginTop: 40,
         }}
       >
         <img
           src={avatarUrl}
-          style={{ width: 80, height: 80, borderRadius: '50%', marginRight: 16 }}
+          width={80}
+          height={80}
+          style={{ width: 80, height: 80, borderRadius: "50%", marginRight: 16 }}
         />
-        <div style={{ display: 'flex', fontSize: 20, fontWeight: 700, color: '#0a0a0a' }}>
+        <div style={{ display: "flex", fontSize: 20, fontWeight: 700, color: "#0a0a0a" }}>
           Lukáš Huvar
         </div>
       </div>

--- a/src/pages/og-image.png.ts
+++ b/src/pages/og-image.png.ts
@@ -15,12 +15,20 @@
  *
  * @module og-image
  */
+import { Buffer } from "node:buffer";
 import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
 import { ImageResponse, GoogleFont, cache } from "cf-workers-og";
 import { OGTemplate } from "../lib/og-template";
 
 /** Disable prerendering so query params and the Workers runtime are available. */
 export const prerender = false;
+
+async function loadAvatarDataUrl(origin: string): Promise<string> {
+  const response = await env.ASSETS.fetch(new URL("/lukas-huvar.jpg", origin));
+  const buffer = await response.arrayBuffer();
+  return `data:image/jpeg;base64,${Buffer.from(buffer).toString("base64")}`;
+}
 
 export const GET: APIRoute = async ({ url, locals }) => {
   cache.setExecutionContext(locals.cfContext);
@@ -29,7 +37,7 @@ export const GET: APIRoute = async ({ url, locals }) => {
   const description =
     url.searchParams.get("description") || "A software developer from the Czech Republic.";
 
-  const avatarUrl = new URL("/lukas-huvar.jpg", url.origin).toString();
+  const avatarUrl = await loadAvatarDataUrl(url.origin);
 
   return ImageResponse.create(OGTemplate({ title, description, avatarUrl }), {
     width: 1200,


### PR DESCRIPTION
## Summary
- Adds `width={80}` and `height={80}` attributes to the avatar `<img>` in the OG image template. `cf-workers-og` (satori) needs explicit sizing on image elements — CSS-only sizing triggered `Image size cannot be determined` errors in production on `/og-image.png`.

## Test plan
- [ ] `bun run build` succeeds
- [ ] `/og-image.png?title=...&description=...` renders a PNG on the deployed worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open Graph image generation now embeds the avatar as an inline data URL and waits for it before producing the image.

* **Style**
  * Updated internal JSX/inline-style formatting and adjusted avatar element attributes for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->