### PR TITLE
feat: add "open to work" banner with mailto link

### DIFF
--- a/src/components/open-to-work.astro
+++ b/src/components/open-to-work.astro
@@ -1,0 +1,24 @@
+---
+---
+
+<aside
+  class="max-w-2xl w-full mx-auto my-4 flex items-center gap-2 text-sm"
+>
+  <span class="relative flex h-2 w-2 shrink-0">
+    <span
+      class="absolute inline-flex h-full w-full rounded-full bg-green-500 opacity-75 animate-ping"
+    ></span>
+    <span
+      class="relative inline-flex rounded-full h-2 w-2 bg-green-500"
+    ></span>
+  </span>
+  <p class="text-stone-500">
+    Open to new opportunities —{' '}
+    <a
+      href="mailto:lukas@huvar.cz"
+      class="font-bold text-gray-900 underline underline-offset-2 hover:text-stone-800"
+    >
+      get in touch
+    </a>
+  </p>
+</aside>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -1,6 +1,7 @@
 ---
 import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/header.astro";
+import OpenToWork from "../components/open-to-work.astro";
 import Footer from "../components/footer.astro";
 import { SITE_TITLE } from "../consts";
 
@@ -24,6 +25,7 @@ const {
     class="min-h-screen bg-white text-gray-900 font-mono antialiased font-size-15 flex flex-col"
   >
     <Header />
+    <OpenToWork />
     <main class="max-w-2xl w-full mx-auto flex flex-col grow">
       <slot />
     </main>


### PR DESCRIPTION
## Summary
- Adds a small `OpenToWork` banner component displayed below the header on every page, signalling availability for new opportunities.
- Includes a pulsing green dot and a `mailto:lukas@huvar.cz` link styled to match the site's monochrome Space Mono aesthetic.
- Wired into `src/layouts/layout.astro` so it appears site-wide.

## Test plan
- [ ] Run `bun dev` and verify the banner renders below the header on home, blog, and TIL pages
- [ ] Click "get in touch" and confirm the mailto opens with the correct address