### PR TITLE
feat: add dark mode support

### DIFF
--- a/astro.config.mts
+++ b/astro.config.mts
@@ -1,25 +1,25 @@
 // @ts-check
-import { defineConfig, fontProviders } from 'astro/config';
-import mdx from '@astrojs/mdx';
-import sitemap from '@astrojs/sitemap';
-import tailwindcss from '@tailwindcss/vite';
-import { h } from 'hastscript';
+import { defineConfig, fontProviders } from "astro/config";
+import mdx from "@astrojs/mdx";
+import sitemap from "@astrojs/sitemap";
+import tailwindcss from "@tailwindcss/vite";
+import { h } from "hastscript";
 
-import cloudflare from '@astrojs/cloudflare';
+import cloudflare from "@astrojs/cloudflare";
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://huvik.dev',
+  site: "https://huvik.dev",
   integrations: [mdx(), sitemap()],
   adapter: cloudflare(),
   fonts: [
     {
-      name: 'Space Mono',
+      name: "Space Mono",
       provider: fontProviders.fontsource(),
-      cssVariable: '--font-space-mono',
+      cssVariable: "--font-space-mono",
       weights: [400, 700],
-      styles: ['normal', 'italic'],
-      subsets: ['latin', 'latin-ext'],
+      styles: ["normal", "italic"],
+      subsets: ["latin", "latin-ext"],
     },
   ],
   vite: {
@@ -28,12 +28,12 @@ export default defineConfig({
   markdown: {
     shikiConfig: {
       themes: {
-        light: 'github-light',
-        dark: 'github-dark',
+        light: "github-light",
+        dark: "github-dark",
       },
       transformers: [
         {
-          name: 'transformer-meta',
+          name: "transformer-meta",
           pre() {
             // This method means that we will modifiy the <pre> element that will be generated
             const metaRaw = this.options.meta?.__raw;
@@ -41,7 +41,7 @@ export default defineConfig({
             if (metaRaw) {
               const parts = metaRaw.split(/\s+/);
               for (const part of parts) {
-                const [key, value] = part.split('=');
+                const [key, value] = part.split("=");
                 if (key && value) {
                   meta[key] = value;
                 }
@@ -51,15 +51,15 @@ export default defineConfig({
           },
         },
         {
-          name: 'code-title',
+          name: "code-title",
           pre(node) {
             const meta = this.meta as Record<string, string>;
             if (meta.title) {
               const titleDiv = h(
-                'div',
+                "div",
                 {
                   class:
-                    'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-b border-gray-300 dark:border-gray-700 px-3 py-2 text-sm font-bold rounded-t-md',
+                    "bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-b border-gray-300 dark:border-gray-700 px-3 py-2 text-sm font-bold rounded-t-md",
                 },
                 meta.title,
               );
@@ -68,61 +68,61 @@ export default defineConfig({
           },
         },
         {
-          name: 'copy-button',
+          name: "copy-button",
           pre(node) {
             // Create copy button placeholder
             const copyButton = h(
-              'button',
+              "button",
               {
                 class:
-                  'copy-code-button absolute top-2 right-2 rounded p-1 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors w-6 h-6 flex items-center justify-center',
-                'aria-label': 'Copy code to clipboard',
-                'data-copied': 'false',
+                  "copy-code-button absolute top-2 right-2 rounded p-1 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors w-6 h-6 flex items-center justify-center",
+                "aria-label": "Copy code to clipboard",
+                "data-copied": "false",
               },
               [
                 h(
-                  'svg',
+                  "svg",
                   {
-                    class: 'copy-icon w-3.5 h-3.5 text-gray-500 dark:text-gray-400',
-                    xmlns: 'http://www.w3.org/2000/svg',
-                    width: '24',
-                    height: '24',
-                    viewBox: '0 0 24 24',
-                    fill: 'none',
-                    stroke: 'currentColor',
-                    'stroke-width': '2',
-                    'stroke-linecap': 'round',
-                    'stroke-linejoin': 'round',
+                    class: "copy-icon w-3.5 h-3.5 text-gray-500 dark:text-gray-400",
+                    xmlns: "http://www.w3.org/2000/svg",
+                    width: "24",
+                    height: "24",
+                    viewBox: "0 0 24 24",
+                    fill: "none",
+                    stroke: "currentColor",
+                    "stroke-width": "2",
+                    "stroke-linecap": "round",
+                    "stroke-linejoin": "round",
                   },
                   [
-                    h('rect', {
-                      width: '14',
-                      height: '14',
-                      x: '8',
-                      y: '8',
-                      rx: '2',
-                      ry: '2',
+                    h("rect", {
+                      width: "14",
+                      height: "14",
+                      x: "8",
+                      y: "8",
+                      rx: "2",
+                      ry: "2",
                     }),
-                    h('path', {
-                      d: 'M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2',
+                    h("path", {
+                      d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2",
                     }),
                   ],
                 ),
                 h(
-                  'svg',
+                  "svg",
                   {
-                    class: 'check-icon w-3.5 h-3.5 text-green-600 dark:text-green-400 hidden',
-                    xmlns: 'http://www.w3.org/2000/svg',
-                    width: '24',
-                    height: '24',
-                    viewBox: '0 0 24 24',
-                    fill: 'none',
-                    stroke: 'currentColor',
-                    'stroke-width': '2',
-                    'stroke-linecap': 'round',
-                    'stroke-linejoin': 'round',
+                    class: "check-icon w-3.5 h-3.5 text-green-600 dark:text-green-400 hidden",
+                    xmlns: "http://www.w3.org/2000/svg",
+                    width: "24",
+                    height: "24",
+                    viewBox: "0 0 24 24",
+                    fill: "none",
+                    stroke: "currentColor",
+                    "stroke-width": "2",
+                    "stroke-linecap": "round",
+                    "stroke-linejoin": "round",
                   },
-                  [h('path', { d: 'M20 6 9 17l-5-5' })],
+                  [h("path", { d: "M20 6 9 17l-5-5" })],
                 ),
               ],
             );

--- a/astro.config.mts
+++ b/astro.config.mts
@@ -58,7 +58,8 @@ export default defineConfig({
               const titleDiv = h(
                 'div',
                 {
-                  class: 'bg-gray-200 p-1 rounded-t-md',
+                  class:
+                    'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-b border-gray-300 dark:border-gray-700 px-3 py-2 text-sm font-bold rounded-t-md',
                 },
                 meta.title,
               );
@@ -74,7 +75,7 @@ export default defineConfig({
               'button',
               {
                 class:
-                  'copy-code-button absolute top-2 right-2 rounded p-1 hover:bg-gray-200 transition-colors w-6 h-6 flex items-center justify-center',
+                  'copy-code-button absolute top-2 right-2 rounded p-1 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors w-6 h-6 flex items-center justify-center',
                 'aria-label': 'Copy code to clipboard',
                 'data-copied': 'false',
               },
@@ -82,7 +83,7 @@ export default defineConfig({
                 h(
                   'svg',
                   {
-                    class: 'copy-icon w-3.5 h-3.5 text-gray-500',
+                    class: 'copy-icon w-3.5 h-3.5 text-gray-500 dark:text-gray-400',
                     xmlns: 'http://www.w3.org/2000/svg',
                     width: '24',
                     height: '24',

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -36,10 +36,23 @@ ogImageUrl.searchParams.set('description', description);
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="color-scheme" content="light dark" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
 <meta name="generator" content={Astro.generator} />
 <Font cssVariable="--font-space-mono" preload />
+
+<!-- Theme init (runs before paint to avoid FOUC) -->
+<script is:inline>
+  (function () {
+    try {
+      var stored = localStorage.getItem('theme');
+      var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      var isDark = stored ? stored === 'dark' : prefersDark;
+      document.documentElement.classList.toggle('dark', isDark);
+    } catch (_) {}
+  })();
+</script>
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />

--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -4,24 +4,48 @@ import { Copyright } from '@lucide/astro';
 ---
 
 <footer
-  class="flex justify-between w-full max-w-2xl mx-auto text-stone-400 my-4"
+  class="flex justify-between w-full max-w-2xl mx-auto text-stone-400 dark:text-stone-500 my-4"
 >
-  <div class="flex gap-2">
+  <div class="flex gap-2 items-center">
     <a
       href="https://github.com/huv1k"
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Github"
+      class="text-stone-600 hover:text-gray-900 dark:text-stone-400 dark:hover:text-gray-100 transition-colors"
     >
-      <img src="/github.svg" width="16" height="16" alt="GitHub" class="fill-current" />
+      <svg
+        role="img"
+        viewBox="0 0 24 24"
+        width="16"
+        height="16"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+        ></path>
+      </svg>
     </a>
     <a
       href="https://x.com/huv1k"
       target="_blank"
       rel="noopener noreferrer"
-      aria-label="Twitter"
+      aria-label="X"
+      class="text-stone-600 hover:text-gray-900 dark:text-stone-400 dark:hover:text-gray-100 transition-colors"
     >
-      <img src="/x.svg" width="16" height="16" alt="X" />
+      <svg
+        role="img"
+        viewBox="0 0 24 24"
+        width="16"
+        height="16"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          d="M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z"
+        ></path>
+      </svg>
     </a>
   </div>
   <div class="flex gap-2 uppercase items-center">

--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -1,11 +1,13 @@
 ---
 import HeaderLink from './header-link.astro';
+import ThemeToggle from './theme-toggle.astro';
 ---
 
-<header class="max-w-2xl w-full mx-auto my-4 flex justify-end">
+<header class="max-w-2xl w-full mx-auto my-4 flex items-center justify-end gap-4">
   <nav class="flex gap-4">
     <HeaderLink href="/">Home</HeaderLink>
     <HeaderLink href="/til">Today I Learned</HeaderLink>
     <HeaderLink href="/blog">Blog</HeaderLink>
   </nav>
+  <ThemeToggle />
 </header>

--- a/src/components/open-to-work.astro
+++ b/src/components/open-to-work.astro
@@ -12,11 +12,11 @@
       class="relative inline-flex rounded-full h-2 w-2 bg-green-500"
     ></span>
   </span>
-  <p class="text-stone-500">
+  <p class="text-stone-500 dark:text-stone-400">
     Open to new opportunities —{' '}
     <a
       href="mailto:lukas@huvar.cz"
-      class="font-bold text-gray-900 underline underline-offset-2 hover:text-stone-800"
+      class="font-bold text-gray-900 dark:text-gray-100 underline underline-offset-2 hover:text-stone-800 dark:hover:text-stone-300"
     >
       get in touch
     </a>

--- a/src/components/speaking.astro
+++ b/src/components/speaking.astro
@@ -26,7 +26,7 @@ const talks = [
         <a href={talk.href} target="_blank" rel="noopener noreferrer">
           {talk.name}
         </a>
-        <p class="text-stone-400">{talk.location}</p>
+        <p class="text-stone-400 dark:text-stone-500">{talk.location}</p>
       </div>
     ))
   }

--- a/src/components/theme-toggle.astro
+++ b/src/components/theme-toggle.astro
@@ -1,0 +1,31 @@
+---
+import { Sun, Moon } from '@lucide/astro';
+---
+
+<button
+  type="button"
+  id="theme-toggle"
+  aria-label="Toggle dark mode"
+  class="inline-flex items-center justify-center rounded p-1 text-stone-500 hover:text-gray-900 dark:text-stone-400 dark:hover:text-gray-100 transition-colors"
+>
+  <Sun size={16} class="block dark:hidden" aria-hidden="true" />
+  <Moon size={16} class="hidden dark:block" aria-hidden="true" />
+</button>
+
+<script>
+  function setupThemeToggle() {
+    const button = document.getElementById('theme-toggle');
+    if (!button || button.hasAttribute('data-listener-attached')) return;
+    button.setAttribute('data-listener-attached', 'true');
+
+    button.addEventListener('click', () => {
+      const isDark = document.documentElement.classList.toggle('dark');
+      try {
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      } catch (_) {}
+    });
+  }
+
+  setupThemeToggle();
+  document.addEventListener('astro:page-load', setupThemeToggle);
+</script>

--- a/src/components/work-experience.astro
+++ b/src/components/work-experience.astro
@@ -47,10 +47,10 @@ const duration = `${formattedFrom} - ${formattedTo}`;
   <div class="flex-1">
     <div class="flex justify-between items-baseline flex-wrap gap-2">
       <h3 class="font-semibold">{company}</h3>
-      <span class="text-stone-400 text-sm">{duration}</span>
+      <span class="text-stone-400 dark:text-stone-500 text-sm">{duration}</span>
     </div>
-    <p class="text-sm text-stone-500">{role}</p>
-    <div class="text-sm text-stone-600 mt-1">
+    <p class="text-sm text-stone-500 dark:text-stone-400">{role}</p>
+    <div class="text-sm text-stone-600 dark:text-stone-300 mt-1">
       <slot />
     </div>
   </div>

--- a/src/components/work.astro
+++ b/src/components/work.astro
@@ -81,7 +81,7 @@ import WorkExperience from "./work-experience.astro";
                     href="https://github.com/vercel/next.js/pull/7296"
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="underline hover:text-stone-800"
+                    class="underline hover:text-stone-800 dark:hover:text-stone-300"
                 >
                     API routes support</a
                 > and other improvements. Also worked on the internal dashboard (DNS
@@ -100,7 +100,7 @@ import WorkExperience from "./work-experience.astro";
                 href="https://v1.prisma.io/docs/1.34/prisma-admin/overview-el3e/"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="underline hover:text-stone-800">Prisma Admin</a
+                class="underline hover:text-stone-800 dark:hover:text-stone-300">Prisma Admin</a
             >, the predecessor of Prisma Studio. Created a virtual data layer on
             top of the actual data to display pending changes that had not yet
             been committed. Also maintained
@@ -108,7 +108,7 @@ import WorkExperience from "./work-experience.astro";
                 href="https://github.com/graphql/graphql-playground"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="underline hover:text-stone-800">GraphQL Playground</a
+                class="underline hover:text-stone-800 dark:hover:text-stone-300">GraphQL Playground</a
             >, IDE for exploring GraphQL APIs.
         </WorkExperience>
     </div>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -22,7 +22,7 @@ const {
     <BaseHead title={title} description={description} />
   </head>
   <body
-    class="min-h-screen bg-white text-gray-900 font-mono antialiased font-size-15 flex flex-col"
+    class="min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100 font-mono antialiased font-size-15 flex flex-col"
   >
     <Header />
     <OpenToWork />

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -23,7 +23,7 @@ const { Content } = await render(post);
 >
   <article class="mb-16">
     <h1 class="text-2xl font-bold uppercase mb-4">{post.data.title}</h1>
-    <div class="flex items-center justify-between mb-8 text-sm text-gray-600">
+    <div class="flex items-center justify-between mb-8 text-sm text-gray-600 dark:text-gray-400">
       <div class="flex items-center gap-3">
         <Image
           src="/lukas-huvar.jpg"
@@ -34,7 +34,7 @@ const { Content } = await render(post);
           inferSize
           loading="eager"
         />
-        <span class="font-bold text-gray-900">Lukáš Huvar</span>
+        <span class="font-bold text-gray-900 dark:text-gray-100">Lukáš Huvar</span>
       </div>
       <time datetime={post.data.date.toISOString()}>
         {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -22,11 +22,11 @@ const posts = (await getCollection('blog')).sort(
           <h2 class="text-xl font-bold mb-2">
             <a href={`/blog/${post.id}`}>{post.data.title}</a>
           </h2>
-          <p class="text-gray-500 text-sm">
+          <p class="text-gray-500 dark:text-gray-400 text-sm">
             <FormattedDate date={post.data.date} />
           </p>
         </div>
-        <p class="text-gray-700 mb-4">{post.data.description}</p>
+        <p class="text-gray-700 dark:text-gray-300 mb-4">{post.data.description}</p>
       </article>
     ))
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,7 @@ import { Image } from "astro:assets";
         loading="eager"
       />
       <div>
-        <p class="text-stone-400">Lukáš Huvar</p>
+        <p class="text-stone-400 dark:text-stone-500">Lukáš Huvar</p>
         <h1 class="text-2xl font-bold uppercase">Huvik</h1>
       </div>
     </div>

--- a/src/pages/til/[...slug].astro
+++ b/src/pages/til/[...slug].astro
@@ -20,7 +20,7 @@ const { Content } = await render(til);
 <Layout title={`Huvik - ${til.data.title}`} description={til.data.description}>
   <article class="mb-16">
     <h1 class="text-2xl font-bold uppercase mb-4">{til.data.title}</h1>
-    <div class="flex items-center justify-between mb-8 text-sm text-gray-600">
+    <div class="flex items-center justify-between mb-8 text-sm text-gray-600 dark:text-gray-400">
       <div class="flex items-center gap-3">
         <Image
           src="/lukas-huvar.jpg"
@@ -31,7 +31,7 @@ const { Content } = await render(til);
           inferSize
           loading="eager"
         />
-        <span class="font-bold text-gray-900">Lukáš Huvar</span>
+        <span class="font-bold text-gray-900 dark:text-gray-100">Lukáš Huvar</span>
       </div>
       <time datetime={til.data.date.toISOString()}>
         {

--- a/src/pages/til/index.astro
+++ b/src/pages/til/index.astro
@@ -28,11 +28,11 @@ const tils = (await getCollection('til')).sort(
           <h2 class="text-xl font-bold mb-2">
             <a href={`/til/${til.id}`}>{til.data.title}</a>
           </h2>
-          <p class="text-gray-500 text-sm">
+          <p class="text-gray-500 dark:text-gray-400 text-sm">
             <FormattedDate date={til.data.date} />
           </p>
         </div>
-        <p class="text-gray-700 mb-4">{til.data.description}</p>
+        <p class="text-gray-700 dark:text-gray-300 mb-4">{til.data.description}</p>
       </article>
     ))
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme inline {
   --font-sans: var(--font-space-mono), "Courier New", monospace;
   --font-mono: var(--font-space-mono), "Courier New", monospace;
@@ -14,6 +16,12 @@
     &:hover {
       @apply underline;
     }
+  }
+
+  html.dark .astro-code,
+  html.dark .astro-code span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
   }
 }
 
@@ -40,7 +48,7 @@
     }
 
     & pre {
-      @apply border-gray-200 border rounded-md overflow-x-auto relative;
+      @apply border-gray-200 dark:border-gray-800 border rounded-md overflow-x-auto relative;
     }
 
     & pre code {
@@ -48,7 +56,7 @@
     }
 
     & code:not(pre code) {
-      @apply bg-gray-100 rounded-md px-1 py-0.5 text-gray-950;
+      @apply bg-gray-100 dark:bg-gray-800 rounded-md px-1 py-0.5 text-gray-950 dark:text-gray-100;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds a light/dark theme toggle (Sun/Moon button) in the header, with `localStorage` persistence and `prefers-color-scheme` fallback
- Inlines a pre-paint script in `BaseHead` to set the `.dark` class before first render, preventing FOUC; also adds `color-scheme` meta
- Registers a Tailwind v4 `@custom-variant dark` and sprinkles `dark:` variants across layout, components, pages, and markdown styles
- Swaps Shiki code blocks to `github-dark` via a `.astro-code` CSS override using the `--shiki-dark` / `--shiki-dark-bg` vars; restyles the code title bar and copy button for contrast in both themes
- Converts footer social icons from `<img>` to inline `<svg>` with `currentColor` so they respond to theme changes

## Test plan
- [ ] Toggle theme from header — body, headings, code, footer icons all switch correctly
- [ ] Reload with dark preferred — no flash of light content
- [ ] Open a post with a titled code block — title readable, copy button fits inside header in both themes