### PR TITLE
fix(seo): drop trailing slash to restore deindexed pages

### DIFF
--- a/astro.config.mts
+++ b/astro.config.mts
@@ -10,6 +10,10 @@ import cloudflare from "@astrojs/cloudflare";
 // https://astro.build/config
 export default defineConfig({
   site: "https://huvik.dev",
+  trailingSlash: "never",
+  build: {
+    format: "file",
+  },
   integrations: [mdx(), sitemap()],
   adapter: cloudflare(),
   fonts: [

--- a/wrangler.json
+++ b/wrangler.json
@@ -4,7 +4,8 @@
   "compatibility_date": "2025-10-08",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    "html_handling": "drop-trailing-slash"
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
## Summary
Cloudflare Workers Static Assets was 307-redirecting no-slash URLs (e.g. `/blog/improve-prototyping-speed-of-prisma`) to their trailing-slash variants. Because 307 is a *temporary* redirect, Google stopped treating the no-slash form as canonical and began deindexing historically ranked posts.

## Changes
- `astro.config.mts`: set `trailingSlash: "never"` and `build.format: "file"` so pages emit as `/path.html` and generated links/sitemap entries omit the trailing slash.
- `wrangler.json`: set `assets.html_handling` to `drop-trailing-slash` so `/path` serves 200 directly and `/path/` redirects to `/path`.

## Result
The URLs Google originally indexed now return 200 again without any redirect hop, which should let the previously ranked pages recover.

## Test plan
- [ ] Verify post-deploy that `https://huvik.dev/blog/improve-prototyping-speed-of-prisma` returns 200
- [ ] Verify `https://huvik.dev/blog/improve-prototyping-speed-of-prisma/` redirects to the no-slash URL
- [ ] Confirm `sitemap-0.xml` lists URLs without trailing slashes
- [ ] Resubmit sitemap in Google Search Console and request reindexing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to remove trailing slashes from URLs for improved consistency and accessibility.
  * Adjusted build output format to optimize site structure and delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->