### PR TITLE
feat(analytics): track social, contact, speaking and theme clicks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,17 @@ src/
 - Follow functional programming patterns when appropriate
 - Implement proper separation of concerns
 
+## Analytics & Event Tracking
+
+- Seline is loaded globally in `BaseHead.astro` for analytics
+- **Always** add Seline tracking to user-initiated clicks on meaningful links/buttons (external links, social profiles, contact, CTAs, speaking/project links, etc.)
+- Prefer Seline's declarative data attributes — no custom JS needed:
+  - `data-seline-event="event_name"` — required, snake_case event name
+  - `data-seline-<property>="value"` — optional properties on the event
+- For dynamic values that only exist at click time (e.g. a toggled state), use the programmatic API: `window.seline?.track('event_name', { prop: value })`
+- Event naming: snake_case, describing the action (e.g. `social_click`, `contact_click`, `speaking_click`, `project_click`, `theme_toggle`)
+- Include a discriminator property so events can be segmented (e.g. `data-seline-network="github"`, `data-seline-talk="…"`, `data-seline-source="open_to_work"`, `{ theme: 'dark' }`)
+
 ## Common Patterns to Follow
 
 - Use Astro's island architecture for interactivity

--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -12,6 +12,8 @@ import { Copyright } from '@lucide/astro';
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Github"
+      data-seline-event="social_click"
+      data-seline-network="github"
       class="text-stone-600 hover:text-gray-900 dark:text-stone-400 dark:hover:text-gray-100 transition-colors"
     >
       <svg
@@ -32,6 +34,8 @@ import { Copyright } from '@lucide/astro';
       target="_blank"
       rel="noopener noreferrer"
       aria-label="X"
+      data-seline-event="social_click"
+      data-seline-network="x"
       class="text-stone-600 hover:text-gray-900 dark:text-stone-400 dark:hover:text-gray-100 transition-colors"
     >
       <svg

--- a/src/components/open-to-work.astro
+++ b/src/components/open-to-work.astro
@@ -16,6 +16,8 @@
     Open to new opportunities —{' '}
     <a
       href="mailto:lukas@huvar.cz"
+      data-seline-event="contact_click"
+      data-seline-source="open_to_work"
       class="font-bold text-gray-900 dark:text-gray-100 underline underline-offset-2 hover:text-stone-800 dark:hover:text-stone-300"
     >
       get in touch

--- a/src/components/speaking.astro
+++ b/src/components/speaking.astro
@@ -23,7 +23,13 @@ const talks = [
   {
     talks.map((talk) => (
       <div class="flex justify-between">
-        <a href={talk.href} target="_blank" rel="noopener noreferrer">
+        <a
+          href={talk.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-seline-event="speaking_click"
+          data-seline-talk={talk.name}
+        >
           {talk.name}
         </a>
         <p class="text-stone-400 dark:text-stone-500">{talk.location}</p>

--- a/src/components/theme-toggle.astro
+++ b/src/components/theme-toggle.astro
@@ -20,9 +20,11 @@ import { Sun, Moon } from '@lucide/astro';
 
     button.addEventListener('click', () => {
       const isDark = document.documentElement.classList.toggle('dark');
+      const theme = isDark ? 'dark' : 'light';
       try {
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        localStorage.setItem('theme', theme);
       } catch (_) {}
+      window.seline?.track('theme_toggle', { theme });
     });
   }
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,4 +1,4 @@
-type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
+type Runtime = import("@astrojs/cloudflare").Runtime<Env>;
 
 declare namespace App {
   interface Locals extends Runtime {}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,3 +3,9 @@ type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
 declare namespace App {
   interface Locals extends Runtime {}
 }
+
+interface Window {
+  seline?: {
+    track: (event: string, data?: Record<string, unknown>) => void;
+  };
+}


### PR DESCRIPTION
## Summary
- Add Seline click tracking to social links (GitHub, X), the "get in touch" mailto, and speaking talk links via `data-seline-event` attributes
- Track theme toggle clicks programmatically via `window.seline.track('theme_toggle', { theme })` so the current theme is captured per click
- Document the Seline tracking convention in `CLAUDE.md` and add a `Window.seline` type declaration

## Test plan
- [ ] Verify events fire in the Seline dashboard for each of: GitHub, X, contact, each talk, and theme toggle