### PR TITLE
fix(cv): correct contact link text to huvik.dev

### DIFF
--- a/cv.md
+++ b/cv.md
@@ -5,7 +5,7 @@
 **Software Developer — AI, React, GraphQL & TypeScript**
 Czech Republic
 
-[huvar.cz](https://huvik.dev/) · [github.com/huv1k](https://github.com/huv1k) · [x.com/huv1k](https://x.com/huv1k)
+[huvik.dev](https://huvik.dev/) · [github.com/huv1k](https://github.com/huv1k) · [x.com/huv1k](https://x.com/huv1k)
 
 ## Summary
 


### PR DESCRIPTION
## Summary

The CV header had a mismatch where the visible link text read `huvar.cz` while its `href` already pointed to `https://huvik.dev/`. Updated the text to `huvik.dev` so it matches the destination domain.

## Test plan

- [ ] Visit `/cv` and confirm the header reads `huvik.dev` and resolves to `https://huvik.dev/`.