### PR TITLE
feat(home): add projects section with untanglecode

### DIFF
--- a/src/components/projects.astro
+++ b/src/components/projects.astro
@@ -1,0 +1,51 @@
+---
+const projects = [
+  {
+    name: "Untanglecode",
+    tagline: "Refactoring tangled codebases into digital gardens",
+    description:
+      "Side project. An AI agent that manages technical debt and ongoing maintenance, keeping codebases healthy so engineers and AI agents can keep shipping.",
+    href: "https://untanglecode.com/",
+    logo: "https://untanglecode.com/favicon.svg",
+  },
+] as const;
+---
+
+<section class="mb-12">
+  <h2 class="text-lg font-bold uppercase mb-4">Projects</h2>
+  <div class="space-y-4">
+    {
+      projects.map((project) => (
+        <div class="flex gap-4">
+          <img
+            src={project.logo}
+            alt={`${project.name} logo`}
+            width="16"
+            height="16"
+            class="w-6 h-6 mt-1 shrink-0"
+          />
+          <div class="flex-1">
+            <h3 class="font-semibold">
+              <a
+                href={project.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-seline-event="project_click"
+                data-seline-project={project.name}
+                class="underline hover:text-stone-800 dark:hover:text-stone-300"
+              >
+                {project.name}
+              </a>
+            </h3>
+            <p class="text-sm text-stone-500 dark:text-stone-400">
+              {project.tagline}
+            </p>
+            <p class="text-sm text-stone-600 dark:text-stone-300 mt-1">
+              {project.description}
+            </p>
+          </div>
+        </div>
+      ))
+    }
+  </div>
+</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../layouts/layout.astro";
 import Speaking from "../components/speaking.astro";
+import Projects from "../components/projects.astro";
 import Work from "../components/work.astro";
 import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
 import { Image } from "astro:assets";
@@ -54,5 +55,6 @@ import { Image } from "astro:assets";
     </p>
   </section>
   <Speaking />
+  <Projects />
   <Work />
 </Layout>


### PR DESCRIPTION
## Summary
- New `Projects` section on the homepage between `Speaking` and `Work`, listing Untanglecode (https://untanglecode.com/) with its tagline plus a side-project description.
- Layout mirrors the `WorkExperience` card (16px favicon left, name + tagline + description right) and uses the site's standard Seline tracking attributes (`project_click` event with a `project` discriminator).

## Test plan
- [ ] `bun dev` and confirm the Projects section renders between Speaking and Work with the SVG favicon, link, tagline, and description.
- [ ] Click the link and confirm it opens https://untanglecode.com/ in a new tab and emits a `project_click` Seline event.
- [ ] Verify dark-mode styling matches the rest of the homepage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated Projects section on the homepage that displays a curated list of projects with logos, taglines, and descriptions. Each project includes a direct link to its homepage. The section is positioned between the Speaking and Work sections for improved content organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->