### PR TITLE
chore(tooling): unify oxlint/oxfmt config and enable Astro linting

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -2,5 +2,5 @@
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "useTabs": false,
   "tabWidth": 2,
-  "singleQuote": true,
+  "singleQuote": true
 }

--- a/astro.config.mts
+++ b/astro.config.mts
@@ -1,29 +1,29 @@
 // @ts-check
-import { defineConfig, fontProviders } from "astro/config";
-import mdx from "@astrojs/mdx";
-import sitemap from "@astrojs/sitemap";
-import tailwindcss from "@tailwindcss/vite";
-import { h } from "hastscript";
+import { defineConfig, fontProviders } from 'astro/config';
+import mdx from '@astrojs/mdx';
+import sitemap from '@astrojs/sitemap';
+import tailwindcss from '@tailwindcss/vite';
+import { h } from 'hastscript';
 
-import cloudflare from "@astrojs/cloudflare";
+import cloudflare from '@astrojs/cloudflare';
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://huvik.dev",
-  trailingSlash: "never",
+  site: 'https://huvik.dev',
+  trailingSlash: 'never',
   build: {
-    format: "file",
+    format: 'file',
   },
   integrations: [mdx(), sitemap()],
-  adapter: cloudflare({ prerenderEnvironment: "node" }),
+  adapter: cloudflare({ prerenderEnvironment: 'node' }),
   fonts: [
     {
-      name: "Space Mono",
+      name: 'Space Mono',
       provider: fontProviders.fontsource(),
-      cssVariable: "--font-space-mono",
+      cssVariable: '--font-space-mono',
       weights: [400, 700],
-      styles: ["normal", "italic"],
-      subsets: ["latin", "latin-ext"],
+      styles: ['normal', 'italic'],
+      subsets: ['latin', 'latin-ext'],
     },
   ],
   vite: {
@@ -32,12 +32,12 @@ export default defineConfig({
   markdown: {
     shikiConfig: {
       themes: {
-        light: "github-light",
-        dark: "github-dark",
+        light: 'github-light',
+        dark: 'github-dark',
       },
       transformers: [
         {
-          name: "transformer-meta",
+          name: 'transformer-meta',
           pre() {
             // This method means that we will modifiy the <pre> element that will be generated
             const metaRaw = this.options.meta?.__raw;
@@ -45,7 +45,7 @@ export default defineConfig({
             if (metaRaw) {
               const parts = metaRaw.split(/\s+/);
               for (const part of parts) {
-                const [key, value] = part.split("=");
+                const [key, value] = part.split('=');
                 if (key && value) {
                   meta[key] = value;
                 }
@@ -55,15 +55,15 @@ export default defineConfig({
           },
         },
         {
-          name: "code-title",
+          name: 'code-title',
           pre(node) {
             const meta = this.meta as Record<string, string>;
             if (meta.title) {
               const titleDiv = h(
-                "div",
+                'div',
                 {
                   class:
-                    "bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-b border-gray-300 dark:border-gray-700 px-3 py-2 text-sm font-bold rounded-t-md",
+                    'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-b border-gray-300 dark:border-gray-700 px-3 py-2 text-sm font-bold rounded-t-md',
                 },
                 meta.title,
               );
@@ -72,61 +72,61 @@ export default defineConfig({
           },
         },
         {
-          name: "copy-button",
+          name: 'copy-button',
           pre(node) {
             // Create copy button placeholder
             const copyButton = h(
-              "button",
+              'button',
               {
                 class:
-                  "copy-code-button absolute top-2 right-2 rounded p-1 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors w-6 h-6 flex items-center justify-center",
-                "aria-label": "Copy code to clipboard",
-                "data-copied": "false",
+                  'copy-code-button absolute top-2 right-2 rounded p-1 hover:bg-gray-300 dark:hover:bg-gray-700 transition-colors w-6 h-6 flex items-center justify-center',
+                'aria-label': 'Copy code to clipboard',
+                'data-copied': 'false',
               },
               [
                 h(
-                  "svg",
+                  'svg',
                   {
-                    class: "copy-icon w-3.5 h-3.5 text-gray-500 dark:text-gray-400",
-                    xmlns: "http://www.w3.org/2000/svg",
-                    width: "24",
-                    height: "24",
-                    viewBox: "0 0 24 24",
-                    fill: "none",
-                    stroke: "currentColor",
-                    "stroke-width": "2",
-                    "stroke-linecap": "round",
-                    "stroke-linejoin": "round",
+                    class: 'copy-icon w-3.5 h-3.5 text-gray-500 dark:text-gray-400',
+                    xmlns: 'http://www.w3.org/2000/svg',
+                    width: '24',
+                    height: '24',
+                    viewBox: '0 0 24 24',
+                    fill: 'none',
+                    stroke: 'currentColor',
+                    'stroke-width': '2',
+                    'stroke-linecap': 'round',
+                    'stroke-linejoin': 'round',
                   },
                   [
-                    h("rect", {
-                      width: "14",
-                      height: "14",
-                      x: "8",
-                      y: "8",
-                      rx: "2",
-                      ry: "2",
+                    h('rect', {
+                      width: '14',
+                      height: '14',
+                      x: '8',
+                      y: '8',
+                      rx: '2',
+                      ry: '2',
                     }),
-                    h("path", {
-                      d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2",
+                    h('path', {
+                      d: 'M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2',
                     }),
                   ],
                 ),
                 h(
-                  "svg",
+                  'svg',
                   {
-                    class: "check-icon w-3.5 h-3.5 text-green-600 dark:text-green-400 hidden",
-                    xmlns: "http://www.w3.org/2000/svg",
-                    width: "24",
-                    height: "24",
-                    viewBox: "0 0 24 24",
-                    fill: "none",
-                    stroke: "currentColor",
-                    "stroke-width": "2",
-                    "stroke-linecap": "round",
-                    "stroke-linejoin": "round",
+                    class: 'check-icon w-3.5 h-3.5 text-green-600 dark:text-green-400 hidden',
+                    xmlns: 'http://www.w3.org/2000/svg',
+                    width: '24',
+                    height: '24',
+                    viewBox: '0 0 24 24',
+                    fill: 'none',
+                    stroke: 'currentColor',
+                    'stroke-width': '2',
+                    'stroke-linecap': 'round',
+                    'stroke-linejoin': 'round',
                   },
-                  [h("path", { d: "M20 6 9 17l-5-5" })],
+                  [h('path', { d: 'M20 6 9 17l-5-5' })],
                 ),
               ],
             );

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,9 +1,13 @@
+# The actual tools/flags live in package.json scripts (single source of truth).
+# This hook just runs those same scripts so the two never drift apart.
 pre-commit:
-  parallel: true
+  # Run sequentially, not in parallel: both scripts auto-fix and re-stage the same
+  # files, so concurrent writes would race and clobber each other's edits.
+  piped: true
   commands:
     format:
-      glob: "*.{js,ts,mts,astro,md,mdx,json,yml,yaml,css}"
-      run: bunx oxfmt -c .oxlintrc.json --no-error-on-unmatched-pattern {staged_files}
+      run: bun run format
+      stage_fixed: true
     lint:
-      glob: "*.{js,ts,mts,astro}"
-      run: bunx oxlint -c .oxlintrc.json {staged_files}
+      run: bun run lint
+      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "deploy": "wrangler deploy",
     "dev": "astro dev",
     "preview": "astro build && wrangler dev",
-    "format": "oxfmt -c .oxlintrc.json .",
-    "lint:fix": "oxlint -c .oxlintrc.json --fix .",
-    "check": "oxfmt -c .oxlintrc.json --check . && oxlint -c .oxlintrc.json ."
+    "format": "oxfmt .",
+    "lint": "oxlint --fix .",
+    "check": "oxfmt --check . && oxlint ."
   },
   "dependencies": {
     "@astrojs/cloudflare": "14.1.0",

--- a/src/content/blog/improve-prototyping-speed-of-prisma.mdx
+++ b/src/content/blog/improve-prototyping-speed-of-prisma.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Improve prototyping speed of Prisma"
-description: "Automate your database updates with one command."
-date: "2020-11-22T18:00:00Z"
-image: "improve-prototyping-speed-of-prisma/og-image.png"
+title: 'Improve prototyping speed of Prisma'
+description: 'Automate your database updates with one command.'
+date: '2020-11-22T18:00:00Z'
+image: 'improve-prototyping-speed-of-prisma/og-image.png'
 ---
 
 [Prisma](https://www.prisma.io/) is a really great "next-generation" ORM. It enables developers to work with databases effortlessly. It had one downside, and that was an annoying prototyping developer experience.

--- a/src/content/blog/my-first-post.mdx
+++ b/src/content/blog/my-first-post.mdx
@@ -1,7 +1,7 @@
 ---
-title: "My First Post!"
-description: "Starting to write my blog finally!"
-date: "2020-10-26T08:41:03Z"
+title: 'My First Post!'
+description: 'Starting to write my blog finally!'
+date: '2020-10-26T08:41:03Z'
 ---
 
 👋 I am Lukáš, most of you know me as **Huvik**, a software developer from the **Czech&nbsp;Republic** passionate about **React**, **TypeScript**, and **GraphQL**.

--- a/src/content/blog/six-years-at-productboard.mdx
+++ b/src/content/blog/six-years-at-productboard.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Six Years at Productboard"
-description: "Reflecting on my journey at Productboard — from frontend platform, design systems, and performance to GraphQL, AI, and gradual deployments."
-date: "2025-04-17T00:00:00Z"
+title: 'Six Years at Productboard'
+description: 'Reflecting on my journey at Productboard — from frontend platform, design systems, and performance to GraphQL, AI, and gradual deployments.'
+date: '2025-04-17T00:00:00Z'
 ---
 
-import YouTube from "../../components/YouTube.astro";
+import YouTube from '../../components/YouTube.astro';
 
 After six years of working at Productboard, I want to reflect on my journey. It was a long ride, so let me walk you through it.
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,4 +1,4 @@
-type Runtime = import("@astrojs/cloudflare").Runtime<Env>;
+type Runtime = import('@astrojs/cloudflare').Runtime<Env>;
 
 declare namespace App {
   interface Locals extends Runtime {}

--- a/src/lib/og-template.ts
+++ b/src/lib/og-template.ts
@@ -1,5 +1,5 @@
-import { createElement } from "react";
-import type { ReactElement } from "react";
+import { createElement } from 'react';
+import type { ReactElement } from 'react';
 
 export type OGTemplateProps = {
   title: string;
@@ -9,26 +9,26 @@ export type OGTemplateProps = {
 
 export function OGTemplate({ title, description, avatarUrl }: OGTemplateProps): ReactElement {
   return createElement(
-    "div",
+    'div',
     {
       style: {
-        display: "flex",
-        flexDirection: "column",
-        width: "100%",
-        height: "100%",
-        backgroundColor: "#ffffff",
-        padding: "80px",
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        height: '100%',
+        backgroundColor: '#ffffff',
+        padding: '80px',
         fontFamily: "'Space Mono', monospace",
       },
     },
     createElement(
-      "div",
+      'div',
       {
         style: {
-          display: "flex",
+          display: 'flex',
           fontSize: 64,
           fontWeight: 700,
-          color: "#0a0a0a",
+          color: '#0a0a0a',
           marginBottom: 24,
           lineHeight: 1.2,
         },
@@ -36,12 +36,12 @@ export function OGTemplate({ title, description, avatarUrl }: OGTemplateProps): 
       title,
     ),
     createElement(
-      "div",
+      'div',
       {
         style: {
-          display: "flex",
+          display: 'flex',
           fontSize: 32,
-          color: "#525252",
+          color: '#525252',
           flex: 1,
           lineHeight: 1.4,
         },
@@ -49,25 +49,25 @@ export function OGTemplate({ title, description, avatarUrl }: OGTemplateProps): 
       description,
     ),
     createElement(
-      "div",
+      'div',
       {
         style: {
-          display: "flex",
-          justifyContent: "flex-end",
-          alignItems: "center",
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
           marginTop: 40,
         },
       },
-      createElement("img", {
+      createElement('img', {
         src: avatarUrl,
         width: 80,
         height: 80,
-        style: { width: 80, height: 80, borderRadius: "50%", marginRight: 16 },
+        style: { width: 80, height: 80, borderRadius: '50%', marginRight: 16 },
       }),
       createElement(
-        "div",
-        { style: { display: "flex", fontSize: 20, fontWeight: 700, color: "#0a0a0a" } },
-        "Lukáš Huvar",
+        'div',
+        { style: { display: 'flex', fontSize: 20, fontWeight: 700, color: '#0a0a0a' } },
+        'Lukáš Huvar',
       ),
     ),
   );

--- a/src/pages/og-image.png.ts
+++ b/src/pages/og-image.png.ts
@@ -15,27 +15,27 @@
  *
  * @module og-image
  */
-import { Buffer } from "node:buffer";
-import type { APIRoute } from "astro";
-import { env } from "cloudflare:workers";
-import { ImageResponse, GoogleFont, cache } from "cf-workers-og";
-import { OGTemplate } from "../lib/og-template";
+import { Buffer } from 'node:buffer';
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+import { ImageResponse, GoogleFont, cache } from 'cf-workers-og';
+import { OGTemplate } from '../lib/og-template';
 
 /** Disable prerendering so query params and the Workers runtime are available. */
 export const prerender = false;
 
 async function loadAvatarDataUrl(origin: string): Promise<string> {
-  const response = await env.ASSETS.fetch(new URL("/lukas-huvar.jpg", origin));
+  const response = await env.ASSETS.fetch(new URL('/lukas-huvar.jpg', origin));
   const buffer = await response.arrayBuffer();
-  return `data:image/jpeg;base64,${Buffer.from(buffer).toString("base64")}`;
+  return `data:image/jpeg;base64,${Buffer.from(buffer).toString('base64')}`;
 }
 
 export const GET: APIRoute = async ({ url, locals }) => {
   cache.setExecutionContext(locals.cfContext);
 
-  const title = url.searchParams.get("title") || "Huvik - software developer";
+  const title = url.searchParams.get('title') || 'Huvik - software developer';
   const description =
-    url.searchParams.get("description") || "A software developer from the Czech Republic.";
+    url.searchParams.get('description') || 'A software developer from the Czech Republic.';
 
   const avatarUrl = await loadAvatarDataUrl(url.origin);
 
@@ -43,11 +43,11 @@ export const GET: APIRoute = async ({ url, locals }) => {
     width: 1200,
     height: 630,
     fonts: [
-      new GoogleFont("Space Mono", { weight: 400 }),
-      new GoogleFont("Space Mono", { weight: 700 }),
+      new GoogleFont('Space Mono', { weight: 400 }),
+      new GoogleFont('Space Mono', { weight: 700 }),
     ],
     headers: {
-      "Cache-Control": "public, max-age=31536000, immutable",
+      'Cache-Control': 'public, max-age=31536000, immutable',
     },
   });
 };

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,9 +1,9 @@
-import rss from "@astrojs/rss";
-import { getCollection } from "astro:content";
-import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 
 export async function GET(context) {
-  const posts = await getCollection("blog");
+  const posts = await getCollection('blog');
   return rss({
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,10 +1,10 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme inline {
-  --font-sans: var(--font-space-mono), "Courier New", monospace;
-  --font-mono: var(--font-space-mono), "Courier New", monospace;
+  --font-sans: var(--font-space-mono), 'Courier New', monospace;
+  --font-mono: var(--font-space-mono), 'Courier New', monospace;
 }
 
 @layer base {


### PR DESCRIPTION
Fixes the oxfmt/oxlint tooling so it works correctly across all supported file types and the pre-commit hook auto-fixes reliably. oxfmt now reads the intended single-quote config via `.oxfmtrc.json` (renamed from `.oxfmtrc.jsonc`) instead of the wrong `.oxlintrc.json`, and both tools rely on config auto-discovery so the redundant `-c` flags are dropped. `package.json` scripts are now the single source of truth — `lefthook.yml` just calls `bun run format` / `bun run lint` (run sequentially via `piped` with `stage_fixed` so fixes are re-staged) instead of duplicating the tool commands, and `lint:fix` is renamed to `lint`. All files flagged by the corrected single-quote config are reformatted. Note: oxlint lints the script portion of `.astro` files, but oxfmt cannot format `.astro` yet, so Astro files are linted only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized quote style and formatting across configuration, content, styles, and helper files.
  * Cleaned up JSON and MDX front matter to keep formatting consistent.
* **Chores**
  * Simplified format and lint commands and updated pre-commit checks to run through project scripts.
  * Minor whitespace and layout adjustments were applied throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->