### PR TITLE
fix: restore missing text spacing and markdown list styles

### DIFF
--- a/src/components/work.astro
+++ b/src/components/work.astro
@@ -76,7 +76,7 @@ import WorkExperience from "./work-experience.astro";
         >
             <p>
                 Helped maintain the <b>Next.js</b> framework repository, triaging
-                issues and reviewing community contributions, and shipped
+                issues and reviewing community contributions, and shipped{' '}
                 <a
                     href="https://github.com/vercel/next.js/pull/7296"
                     target="_blank"
@@ -103,7 +103,7 @@ import WorkExperience from "./work-experience.astro";
                 class="underline hover:text-stone-800 dark:hover:text-stone-300">Prisma Admin</a
             >, the predecessor of Prisma Studio. Created a virtual data layer on
             top of the actual data to display pending changes that had not yet
-            been committed. Also maintained
+            been committed. Also maintained{' '}
             <a
                 href="https://github.com/graphql/graphql-playground"
                 target="_blank"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -43,6 +43,19 @@
     & p {
       @apply my-2;
     }
+
+    & ul {
+      @apply list-disc pl-6 my-2;
+    }
+
+    & ol {
+      @apply list-decimal pl-6 my-2;
+    }
+
+    & li {
+      @apply my-1;
+    }
+
     & a {
       @apply font-bold underline;
     }


### PR DESCRIPTION
Two rendering fixes visible on the live site.

- **Missing spaces** (`work.astro`): added explicit `{' '}` at two text-to-`<a>` boundaries where Astro collapsed newline-only whitespace, which was rendering as `shippedAPI routes support` and `maintainedGraphQL Playground`.
- **Missing list styles** (`global.css`): added `ul`/`ol`/`li` rules to the `.markdown` class so Tailwind v4 Preflight no longer strips bullet/number markers and indentation on `/blog`, `/til`, and `/cv`.

Verified end-to-end against the dev server and `bun run check` passes.