### PR TITLE
fix: wrong date in Productboard post

### DIFF
--- a/src/content/blog/six-years-at-productboard.mdx
+++ b/src/content/blog/six-years-at-productboard.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Six Years at Productboard'
 description: 'Reflecting on my journey at Productboard — from frontend platform, design systems, and performance to GraphQL, AI, and gradual deployments.'
-date: '2025-04-17T00:00:00Z'
+date: '2026-04-17T00:00:00Z'
 ---
 
 import YouTube from '../../components/YouTube.astro';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated the publication date for the “Six Years at Productboard” blog post to April 17, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->