### PR TITLE
Fix canonical URLs for prerendered pages

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -20,7 +20,15 @@ export interface Props {
   description: string;
 }
 
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+// Astro uses `.html` paths while prerendering with `build.format: 'file'`.
+// Strip that build-only suffix (and trailing slashes) so metadata matches the
+// public URLs emitted by the sitemap and used throughout the site.
+const publicPath =
+  Astro.url.pathname
+    .replace(/\/index\.html$/, '/')
+    .replace(/\.html$/, '')
+    .replace(/\/+$/, '') || '/';
+const canonicalURL = new URL(publicPath, Astro.site);
 
 const { title, description } = Astro.props as Props;
 
@@ -64,14 +72,14 @@ ogImageUrl.searchParams.set('description', description);
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />
-<meta property="og:url" content={Astro.url} />
+<meta property="og:url" content={canonicalURL} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={ogImageUrl} />
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={Astro.url} />
+<meta property="twitter:url" content={canonicalURL} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={ogImageUrl} />


### PR DESCRIPTION
Normalize canonical, Open Graph, and Twitter URLs to the public slashless paths. Astro's file-format prerendering was exposing build-only .html URLs, causing Google to choose a different canonical for blog and TIL pages. Verified with a production build, sitemap comparison, TypeScript, and lint checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canonical URL generation for prerendered pages.
  * Removed unnecessary trailing slashes and added a safe fallback URL.
  * Updated Open Graph and Twitter metadata to use the normalized canonical URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->